### PR TITLE
Fixes typo in create-cluster.sh

### DIFF
--- a/examples/docker-machine/create-cluster.sh
+++ b/examples/docker-machine/create-cluster.sh
@@ -97,7 +97,7 @@ master_config=$(docker-machine config 'kube-4')
 
 docker ${master_config} run \
   -v /var/run/docker.sock:/docker.sock \
-    weaveworks/kubernetes-anywhere:toolboxs \
+    weaveworks/kubernetes-anywhere:toolbox \
       create-pki-containers
 
 ## Run intermediate containers to export the TLS config volumes for master components


### PR DESCRIPTION
Fixes typo in `create-cluster.sh` for Docker Machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/kubernetes-anywhere/58)
<!-- Reviewable:end -->
