### PR TITLE
make setup-single-node more robust when pki images have been deleted

### DIFF
--- a/docker-images/toolbox/scripts/setup-single-node
+++ b/docker-images/toolbox/scripts/setup-single-node
@@ -6,7 +6,7 @@ setup-kubelet-volumes
 num_pki_images="$(docker images --filter "label=io.k8s/KubernetesAnywhere/pki=true" --quiet | wc -l)"
 num_pki_containers="$(docker ps --all --filter "label=io.k8s/KubernetesAnywhere/pki=true" --quiet | wc -l)"
 
-if [ "${num_pki_images}" -eq 0 ] && [ "${num_pki_containers}" -eq 0 ] ; then
+if [ "${num_pki_containers}" -eq 0 ] ; then
   echo "Creating single-node Public Key Infrastructure (PKI)..."
   echo "Creating local container images (\`kubernetes-anywhere:*-pki\`)..."
   create-pki-containers > /dev/null 2>&1
@@ -23,7 +23,7 @@ if [ "${num_pki_images}" -eq 0 ] && [ "${num_pki_containers}" -eq 0 ] ; then
     kubernetes-anywhere:proxy-pki
   docker run --name=kube-toolbox-pki \
     kubernetes-anywhere:toolbox-pki
-elif [ "${num_pki_images}" -ne 6 ] && [ "${num_pki_containers}" -ne 6 ] ; then
+elif [ "${num_pki_images}" -ne 6 ] || [ "${num_pki_containers}" -ne 6 ] ; then
   echo "Detected an unexpected PKI configuration, it might need tidying up..."
   echo "You have ${num_pki_images} images and ${num_pki_containers} containers,"
   echo "it's expected to have 6 of each on a single-node cluster."


### PR DESCRIPTION
Fixes #73, I think.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/kubernetes-anywhere/76)
<!-- Reviewable:end -->
