### PR TITLE
Split build-and-push into 2 separate scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     sources:
       - debian-sid    # Grab shellcheck from the Debian repo (o_O)
     packages:
-      - shellcheck
+      - cabal-install
 
 services:
   - docker
@@ -14,6 +14,9 @@ env:
   - DOCKER_RELEASE="1.10.3" WEAVE_RELEASE="v1.5.1" KUBERNETES_RELEASE="v1.2.4" FORCE_USERSPACE_PROXY="yes"
 
 install:
+  - export PATH="${HOME}/.cabal/bin:${PATH}"
+  - cabal update
+  - cabal install shellcheck
   - sudo service docker stop
   - sudo curl --silent --location https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_RELEASE} --output /usr/bin/docker
   - sudo chmod +x /usr/bin/docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 script:
   - ./test-shellcheck
-  - env NO_PUSH=1 ./build-and-push ${KUBERNETES_RELEASE}
+  - ./build "${KUBERNETES_RELEASE}"
   - ./test-docker-compose
   - docker ps
   - docker images

--- a/build
+++ b/build
@@ -1,0 +1,47 @@
+#!/bin/bash -x
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "./config"
+
+dir="./docker-images"
+
+printf "FROM gcr.io/google_containers/hyperkube:%s\n%s\n" \
+  "${kubernetes_release}" "${common}" \
+  | docker build --tag="temp/hyperkube" -
+
+for i in kubelet proxy apiserver controller-manager scheduler ; do
+  docker build \
+    --tag="${image_prefix}${i}-${kubernetes_release}" \
+    --file="${dir}/${i}.dockerfile" "${dir}"
+done
+
+printf "FROM gcr.io/google_containers/etcd:2.2.1\n%s\n" "${common}" \
+  | docker build --tag="temp/etcd" -
+
+docker build \
+  --tag="${image_prefix}etcd-${kubernetes_release}" \
+  --file="${dir}/etcd.dockerfile" "${dir}"
+
+printf "FROM centos:7\nENV KUBERNETES_ANYWHERE_TOOLBOX_IMAGE=%s\n%s\n" \
+  "${image_prefix}toolbox-${kubernetes_release}" "${common}" \
+  | docker build --tag="temp/toolbox" -
+
+docker build \
+  --tag="${image_prefix}toolbox-${kubernetes_release}" \
+  --build-arg="KUBERNETES_RELEASE=${kubernetes_release}" \
+  --build-arg="DOCKER_RELEASE=${toolbox_docker_release}" \
+  --build-arg="COMPOSE_RELEASE=${toolbox_compose_release}" \
+  --build-arg="JQ_RELEASE=${toolbox_jq_release}" \
+  --build-arg="EASYRSA_RELEASE=${toolbox_easyrsa_release}" \
+  --file="${dir}/toolbox.dockerfile" "${dir}"
+
+for c in "${components[@]}" ; do
+  img="${image_prefix}${c}"
+  docker tag "${img}-${kubernetes_release}" "${img}-${kubernetes_release_short}"
+  if [ "${kubernetes_release}" = "${default_kubernetes_release}" ] ; then
+    docker tag "${img}-${kubernetes_release}" "${image_prefix}${c}"
+  fi
+done

--- a/build-and-push
+++ b/build-and-push
@@ -1,81 +1,17 @@
-#!/bin/bash -x
+#!/bin/bash
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
-do_build() {
-  [ -n "${NO_BUILD+x}" ] || docker build "$@"
-}
+source "./config"
 
-do_push() {
-  [ -n "${NO_PUSH+x}" ] || docker push "${1}"
-}
+if [ -z "${NO_BUILD+x}" ] ; then
+  echo "Building images for Kubernetes version ${kubernetes_release}..."
+  "./build" "$@"
+fi
 
-git_repo="https://github.com/weaveworks/weave-kubernetes-anywhere"
-git_rev=$(git rev-parse @)
-
-dir="$(git rev-parse --show-toplevel)/docker-images"
-
-default_kubernetes_release="v1.2.4"
-
-kubernetes_release=${1:-"${default_kubernetes_release}"}
-kubernetes_release_base="${kubernetes_release/-[a-z]*\.[0-9]/}"
-kubernetes_release_short="${kubernetes_release_base%.*}"
-
-toolbox_docker_release="1.10.3"
-toolbox_compose_release="1.7.0"
-toolbox_jq_release="1.5"
-toolbox_easyrsa_release="3.0.1"
-
-image_prefix=${2:-"weaveworks/kubernetes-anywhere:"}
-
-common="
-LABEL io.k8s.release=${kubernetes_release}
-LABEL works.weave.role=system
-LABEL com.git-scm.repo=${git_repo}
-LABEL com.git-scm.rev=${git_rev}
-ENV KUBERNETES_RELEASE=${kubernetes_release}
-ENV KUBERNETES_RELEASE_SHORT=${kubernetes_release_short}
-"
-
-printf "FROM gcr.io/google_containers/hyperkube:%s\n%s\n" \
-  "${kubernetes_release}" "${common}" \
-  | do_build --tag="temp/hyperkube" -
-
-for i in kubelet proxy apiserver controller-manager scheduler ; do
-  do_build \
-    --tag="${image_prefix}${i}-${kubernetes_release}" \
-    --file="${dir}/${i}.dockerfile" "${dir}"
-done
-
-printf "FROM gcr.io/google_containers/etcd:2.2.1\n%s\n" "${common}" \
-  | do_build --tag="temp/etcd" -
-
-do_build \
-  --tag="${image_prefix}etcd-${kubernetes_release}" \
-  --file="${dir}/etcd.dockerfile" "${dir}"
-
-printf "FROM centos:7\nENV KUBERNETES_ANYWHERE_TOOLBOX_IMAGE=%s\n%s\n" \
-  "${image_prefix}toolbox-${kubernetes_release}" "${common}" \
-  | do_build --tag="temp/toolbox" -
-
-do_build \
-  --tag="${image_prefix}toolbox-${kubernetes_release}" \
-  --build-arg="KUBERNETES_RELEASE=${kubernetes_release}" \
-  --build-arg="DOCKER_RELEASE=${toolbox_docker_release}" \
-  --build-arg="COMPOSE_RELEASE=${toolbox_compose_release}" \
-  --build-arg="JQ_RELEASE=${toolbox_jq_release}" \
-  --build-arg="EASYRSA_RELEASE=${toolbox_easyrsa_release}" \
-  --file="${dir}/toolbox.dockerfile" "${dir}"
-
-for c in kubelet proxy apiserver controller-manager scheduler toolbox etcd ; do
-  img="${image_prefix}${c}"
-  do_push "${img}-${kubernetes_release}"
-  docker tag "${img}-${kubernetes_release}" "${img}-${kubernetes_release_short}"
-  do_push "${img}-${kubernetes_release_short}"
-  if [ "${kubernetes_release}" = "${default_kubernetes_release}" ] ; then
-    docker tag "${img}-${kubernetes_release}" "${image_prefix}${c}"
-    do_push "${img}"
-  fi
-done
+if [ -z "${NO_PUSH+x}" ] ; then
+  echo "Pushing images for Kubernetes version ${kubernetes_release}..."
+  "./push" "$@"
+fi

--- a/config
+++ b/config
@@ -1,0 +1,27 @@
+## build configuration
+git_repo="https://github.com/weaveworks/weave-kubernetes-anywhere"
+git_rev=$(git rev-parse @)
+
+default_kubernetes_release="v1.2.4"
+
+kubernetes_release=${1:-"${default_kubernetes_release}"}
+kubernetes_release_base="${kubernetes_release/-[a-z]*\.[0-9]/}"
+kubernetes_release_short="${kubernetes_release_base%.*}"
+
+toolbox_docker_release="1.10.3"
+toolbox_compose_release="1.7.0"
+toolbox_jq_release="1.5"
+toolbox_easyrsa_release="3.0.1"
+
+image_prefix=${2:-"weaveworks/kubernetes-anywhere:"}
+
+common="
+LABEL io.k8s.release=${kubernetes_release}
+LABEL works.weave.role=system
+LABEL com.git-scm.repo=${git_repo}
+LABEL com.git-scm.rev=${git_rev}
+ENV KUBERNETES_RELEASE=${kubernetes_release}
+ENV KUBERNETES_RELEASE_SHORT=${kubernetes_release_short}
+"
+
+components=(kubelet proxy apiserver controller-manager scheduler toolbox etcd)

--- a/push
+++ b/push
@@ -1,0 +1,16 @@
+#!/bin/bash -x
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "./config"
+
+for c in "${components[@]}" ; do
+  img="${image_prefix}${c}"
+  docker push "${img}-${kubernetes_release}"
+  docker push "${img}-${kubernetes_release_short}"
+  if [ "${kubernetes_release}" = "${default_kubernetes_release}" ] ; then
+    docker push "${img}"
+  fi
+done

--- a/test-shellcheck
+++ b/test-shellcheck
@@ -19,5 +19,5 @@ _bin_sh=(
   ./docker-images/weave-fix-nameserver.sh
 )
 
-shellcheck -s bash "${_bin_bash[@]}"
-shellcheck -s sh "${_bin_sh[@]}"
+shellcheck -x -s bash "${_bin_bash[@]}"
+shellcheck -x -s sh "${_bin_sh[@]}"


### PR DESCRIPTION
NO_PUSH and NO_BUILD are unintuitive, and didn't seem to work for me (leading me to accidentally push to docker hub. This seems safer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/kubernetes-anywhere/80)
<!-- Reviewable:end -->
